### PR TITLE
Rewrite q.bat in javascript to be run from node

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
   "electronVersion": "0.30.7",
   "greenworksVersion": "0.4.1",
   "javaVersion": "7u80",
+  "scripts": {
+    "q": "node q.js"
+  },
   "devDependencies": {
     "coffee-script": "^1.9.2",
     "electron-packager": "^5.0.0",
     "electron-prebuilt": "0.30.7",
     "electron-rebuild": "^0.2.0",
+    "fs-extra": "^7.0.1",
     "gulp": "^3.9.0",
     "gulp-asar": "git://github.com/danshick/gulp-asar.git",
     "gulp-chmod": "^1.2.0",

--- a/q.js
+++ b/q.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
 const fs = require('fs-extra');
+const path = require('path');
 const program = require('commander');
 
 var cache_backup_path = "./.cache";
 var java_options = "-Xmx=256m";
+var steamDirectory = 'f:/Steam/SteamApps/common/StarMade';
 
 var launcherArgs = [];
-// any args after -- should be passed directly to the launcher 
+// any args after -- should be passed directly to the launcher
 var passthroughIndex = process.argv.indexOf('--');
 if (passthroughIndex >= 0)
 {
@@ -20,25 +22,24 @@ if (passthroughIndex >= 0)
 program
     .version('0.1.0')
     .description('Quick launch utility')
-    .option('-p, --package',       'Packages the launcher for the current platform')
-    .option('-P, --platform <platform>',  'Packages the launcher (all platforms)', process.platform)
+    .option('-p, --package',             'Packages the launcher for the current platform')
+    .option('-P, --platform <platform>', 'Packages the launcher (all platforms)', process.platform)
     .option('-A, --arch <arch>',         'Use the 32bit launcher for all actions', process.arch)
-    .option('-c, --clean',         'Clears the  launcher cache to simulate a fresh install')
-    .option('-C, --clear-cache',  'Clears both launcher and backup caches')
-    .option('-l, --launch',        'Runs the launcher with any passed flags')
-    .option('-j, --javaoptions',   'Populates _JAVA_OPTIONS for this launch')
-    .option('-h, --help',          'Passes --help')
-    .option('-s, --steam',         'Passes --steam        (Implies    --attach, --noupdate)')
-    .option('-a, --attach',        'Passes --attach')
-    .option('-d, --detach',        'Passes --detach       (Overwrites --attach)')
-    .option('-N, --noupdate',    'passes --noupdate')
-    .option('-v, --debugging',     'Passes --noupdate --debugging')
-    .option('-vv, --verbose',      'Passes --noupdate --debugging --verbose')
-    .option('-D, --development', 'Passes --development')
-    .option('-T, --capture',     'Passes --capture-game-log')
-    .option('-t, --test',          'Runs the launcher with --debugging')
-    .option('-tt, --test-verbose', 'Runs the launcher with --debugging --verbose')
-    .option('-O, --dest <steam|vm>', 'Destination either steam or vm?')
+    .option('-c, --clean',               'Clears the  launcher cache to simulate a fresh install')
+    .option('-C, --clear-cache',         'Clears both launcher and backup caches')
+    .option('-l, --launch',              'Runs the launcher with any passed flags')
+    .option('-j, --javaoptions',         'Populates JAVA_OPTIONS for this launch')
+    .option('-s, --steam',               'Passes --steam        (Implies    --attach, --noupdate)')
+    .option('-a, --attach',              'Passes --attach')
+    .option('-d, --detach',              'Passes --detach       (Overwrites --attach)')
+    .option('-N, --noupdate',            'passes --noupdate')
+    .option('-v, --debugging',           'Passes --noupdate --debugging')
+    .option('-V, --verbose',             'Passes --noupdate --debugging --verbose')
+    .option('-D, --development',         'Passes --development')
+    .option('-T, --capture',             'Passes --capture-game-log')
+    .option('-t, --test',                'Runs the launcher with --debugging')
+    .option('-tt, --test-verbose',       'Runs the launcher with --debugging --verbose')
+    .option('-O, --dest <dest>',         'Destination either steam or vm?')
     .parse(process.argv);
 
 // Since we've overridden the standard help behaviour. Show help when no args are given
@@ -49,18 +50,46 @@ if (program.package)
 {
     console.log(`Packaging for ${program.platform} (${program.arch})`);
     const child = execSync(
-        `node node_modules/gulp/bin/gulp.js package --platform ${program.package} --arch ${program.arch}`,
+        `node node_modules/gulp/bin/gulp.js package --platform ${program.platform} --arch ${program.arch}`,
         { stdio: 'inherit' }
     );
 }
 
-if (program.dest === "steam")
+if (program.dest)
 {
-    console.log(`Removing previous steam install`);
-} 
-if (program.dest === 'vm')
-{
-    console.log(`Removing previous VM builds`);
+    if (fs.pathExistsSync(program.dest))
+    {
+        console.log(`Removing old files from ${program.dest}`);
+        const files = fs.readdirSync(program.dest, { withFileTypes: true });
+        files.forEach(ent => {
+            // Do not remove existing StarMade directory
+            if (ent.isDirectory() && ent.name === 'StarMade')
+            {
+                console.log(`Skipping directory ${ent.name}`);
+                return;
+            }
+            if (ent.isFile() && ent.name.toUpperCase() === 'starmade-starter.exe'.toUpperCase())
+            {
+                console.log(`Skipping file ${ent.name}`);
+                return;
+            }
+
+            fs.removeSync(ent.name);
+        });
+    }
+    else
+    {
+        console.log(`Creating directory ${program.dest}`);
+        fs.ensureDirSync(program.dest);
+    }
+
+    // Use current process plaltform and arch incase 'all' has been set in arguments
+    const platform = program.platform === 'all' ? process.platform : program.platform;
+    const arch = program.arch === 'all' ? process.arch : program.arch;
+
+    console.log(`Copying new ${platform} (${arch}) build to ${program.dest}`);
+    fs.copySync(`./dist/starmade-launcher-${platform}-${arch}/`, program.dest);
+
 }
 if (program.clearCache)
 {
@@ -75,6 +104,32 @@ if (program.clean)
     fs.removeSync(`./dist/starmade-launcher-${platform}-${arch}/.cache`);
 }
 
+function restoreCache(launch_dir)
+{
+    console.log("Restoring cache");
+    if (!fs.existsSync('.cache'))
+    {
+        console.log("No cache found");
+    }
+    else
+    {
+        fs.copySync(cache_backup_path, path.join(launch_dir, '.cache'));
+    }
+}
+
+function saveCache(launchDir)
+{
+    console.log("Saving cache");
+    if (!fs.existsSync(path.join(launch_dir, '.cache')))
+    {
+        console.log("No cache found");
+    }
+    else
+    {
+        fs.copySync(path.join(launch_dir, '.cache'), cache_backup_path);
+    }
+}
+
 if (program.launch)
 {
     // Use current process plaltform and arch incase 'all' has been set in arguments
@@ -82,8 +137,38 @@ if (program.launch)
     const arch = program.arch === 'all' ? process.arch : program.arch;
 
     launch_dir = `./dist/starmade-launcher-${platform}-${arch}`;
-    if (program.dest === 'steam')
+    if (program.dest)
+        launch_dir = program.dest;
+
+    if (program.steam) launcherArgs.push('--steam');
+    if (program.attach) launcherArgs.push('--attach');
+    if (program.noupdate) launcherArgs.push('--noupdate');
+    if (program.development)
     {
-        launch_dir = 'f:/Steam/SteamApps/common/StarMade'
+        launcherArgs.push('--development');
     }
+    if (program.verbose)
+    {
+        launcherArgs.push('--noupdate');
+        launcherArgs.push('--debugging');
+        launcherArgs.push('--verbose');
+    }
+    else if (program.debugging)
+    {
+        launcherArgs.push('--noupdate');
+        launcherArgs.push('--debugging');
+    }
+    if (program.capture) launcherArgs.push('--capture-game-log');
+
+    if (!program.clean)
+        restoreCache(launch_dir);
+
+    console.log("command", `${path.join(launch_dir, 'starmade-launcher')} ${launcherArgs.join(' ')}`)
+    const child = execSync(
+        `${path.join(launch_dir, 'starmade-launcher')} ${launcherArgs.join(' ')}`,
+        { stdio: 'inherit' }
+    );
+
+    if (!program.clean)
+        saveCache(launch_dir);
 }

--- a/q.js
+++ b/q.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs-extra');
+const program = require('commander');
+
+var cache_backup_path = "./.cache";
+var java_options = "-Xmx=256m";
+
+var launcherArgs = [];
+// any args after -- should be passed directly to the launcher 
+var passthroughIndex = process.argv.indexOf('--');
+if (passthroughIndex >= 0)
+{
+    launcherArgs = process.argv.slice(passthroughIndex + 1);
+    process.argv = process.argv.slice(0, passthroughIndex);
+    console.log("launcherArgs", launcherArgs);
+    console.log("process.argv", process.argv);
+}
+
+program
+    .version('0.1.0')
+    .description('Quick launch utility')
+    .option('-p, --package',       'Packages the launcher for the current platform')
+    .option('-P, --platform <platform>',  'Packages the launcher (all platforms)', process.platform)
+    .option('-A, --arch <arch>',         'Use the 32bit launcher for all actions', process.arch)
+    .option('-c, --clean',         'Clears the  launcher cache to simulate a fresh install')
+    .option('-C, --clear-cache',  'Clears both launcher and backup caches')
+    .option('-l, --launch',        'Runs the launcher with any passed flags')
+    .option('-j, --javaoptions',   'Populates _JAVA_OPTIONS for this launch')
+    .option('-h, --help',          'Passes --help')
+    .option('-s, --steam',         'Passes --steam        (Implies    --attach, --noupdate)')
+    .option('-a, --attach',        'Passes --attach')
+    .option('-d, --detach',        'Passes --detach       (Overwrites --attach)')
+    .option('-N, --noupdate',    'passes --noupdate')
+    .option('-v, --debugging',     'Passes --noupdate --debugging')
+    .option('-vv, --verbose',      'Passes --noupdate --debugging --verbose')
+    .option('-D, --development', 'Passes --development')
+    .option('-T, --capture',     'Passes --capture-game-log')
+    .option('-t, --test',          'Runs the launcher with --debugging')
+    .option('-tt, --test-verbose', 'Runs the launcher with --debugging --verbose')
+    .option('-O, --dest <steam|vm>', 'Destination either steam or vm?')
+    .parse(process.argv);
+
+// Since we've overridden the standard help behaviour. Show help when no args are given
+if (process.argv.length < 3)
+    program.help();
+
+if (program.package)
+{
+    console.log(`Packaging for ${program.platform} (${program.arch})`);
+    const child = execSync(
+        `node node_modules/gulp/bin/gulp.js package --platform ${program.package} --arch ${program.arch}`,
+        { stdio: 'inherit' }
+    );
+}
+
+if (program.dest === "steam")
+{
+    console.log(`Removing previous steam install`);
+} 
+if (program.dest === 'vm')
+{
+    console.log(`Removing previous VM builds`);
+}
+if (program.clearCache)
+{
+    console.log(`Clearing backup cache`);
+    fs.removeSync(cache_backup_path);
+}
+if (program.clean)
+{
+    const platform = program.platform === 'all' ? '*' : program.platform;
+    const arch = program.arch === 'all' ? '*' : program.arch;
+    console.log(`Clearing launcher cache ${program.platform} (${program.arch})`);
+    fs.removeSync(`./dist/starmade-launcher-${platform}-${arch}/.cache`);
+}
+
+if (program.launch)
+{
+    // Use current process plaltform and arch incase 'all' has been set in arguments
+    const platform = program.platform === 'all' ? process.platform : program.platform;
+    const arch = program.arch === 'all' ? process.arch : program.arch;
+
+    launch_dir = `./dist/starmade-launcher-${platform}-${arch}`;
+    if (program.dest === 'steam')
+    {
+        launch_dir = 'f:/Steam/SteamApps/common/StarMade'
+    }
+}


### PR DESCRIPTION
Major difference is that `--dest` is no longer *steram* or *vm* but now a path. As it doesn't make sense to hard code absolute paths in scripts.

Example usage:
```bash
node q.js --package --platform linux --arch x64 --launch --steam --dest /opt/steam/steamapps/common/StarMade
# or
node q.js -pls --dest /opt/steam/steamapps/common/StarMade
```